### PR TITLE
feat: Add data attrs for shape styles

### DIFF
--- a/examples/tldraw-example/src/styles.css
+++ b/examples/tldraw-example/src/styles.css
@@ -46,3 +46,16 @@ body {
 .links a:hover {
   background-color: rgba(144, 144, 144, 0.1);
 }
+
+/* Example of overriding styles, for local testing */
+/* [data-color=violet] {
+  color: green !important;
+}
+
+[data-color=violet] [stroke] {
+  stroke: green !important;
+}
+
+[data-color=violet] [fill] {
+  fill: green !important;
+} */

--- a/packages/core/src/components/SVGContainer/SVGContainer.tsx
+++ b/packages/core/src/components/SVGContainer/SVGContainer.tsx
@@ -4,15 +4,22 @@ import * as React from 'react'
 interface SvgContainerProps extends React.SVGProps<SVGSVGElement> {
   children: React.ReactNode
   className?: string
+  shapeStyle?: Record<string, any>
 }
 
 export const SVGContainer = React.forwardRef<SVGSVGElement, SvgContainerProps>(
-  function SVGContainer({ id, className = '', children, ...rest }, ref) {
+  function SVGContainer({ id, className = '', children, shapeStyle, ...rest }, ref) {
+    const styleAttrs = shapeStyle
+      ? {
+          'data-color': shapeStyle.color,
+          'data-fill': shapeStyle.isFilled,
+        }
+      : {}
     return (
       <Observer>
         {() => (
           <svg ref={ref} className={`tl-positioned-svg ${className}`} {...rest}>
-            <g id={id} className="tl-centered-g">
+            <g id={id} className="tl-centered-g" {...styleAttrs}>
               {children}
             </g>
           </svg>

--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tldraw/tldraw",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "description": "A tiny little drawing app (editor)",
   "author": "@steveruizok",
   "repository": {

--- a/packages/tldraw/src/state/shapes/ArrowUtil/ArrowUtil.tsx
+++ b/packages/tldraw/src/state/shapes/ArrowUtil/ArrowUtil.tsx
@@ -137,8 +137,9 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
             isEditing={isEditing}
             onChange={handleLabelChange}
             onBlur={onShapeBlur}
+            shape={shape}
           />
-          <SVGContainer id={shape.id + '_svg'}>
+          <SVGContainer id={shape.id + '_svg'} shapeStyle={style}>
             <defs>
               <mask id={shape.id + '_clip'}>
                 <rect

--- a/packages/tldraw/src/state/shapes/EllipseUtil/EllipseUtil.tsx
+++ b/packages/tldraw/src/state/shapes/EllipseUtil/EllipseUtil.tsx
@@ -87,8 +87,13 @@ export class EllipseUtil extends TDShapeUtil<T, E> {
             color={styles.stroke}
             offsetX={(labelPoint[0] - 0.5) * bounds.width}
             offsetY={(labelPoint[1] - 0.5) * bounds.height}
+            shape={shape}
           />
-          <SVGContainer id={shape.id + '_svg'} opacity={isGhost ? GHOSTED_OPACITY : 1}>
+          <SVGContainer
+            id={shape.id + '_svg'}
+            opacity={isGhost ? GHOSTED_OPACITY : 1}
+            shapeStyle={style}
+          >
             {isBinding && (
               <ellipse
                 className="tl-binding-indicator"

--- a/packages/tldraw/src/state/shapes/ImageUtil/ImageUtil.tsx
+++ b/packages/tldraw/src/state/shapes/ImageUtil/ImageUtil.tsx
@@ -78,6 +78,7 @@ export class ImageUtil extends TDShapeUtil<T, E> {
             isDarkMode={meta.isDarkMode} //
             isFilled={style.isFilled}
             isGhost={isGhost}
+            // data-image-wrapper
           >
             <ImageElement
               id={shape.id + '_image'}
@@ -160,16 +161,16 @@ const Wrapper = styled('div', {
       isFilled: true,
       isDarkMode: true,
       css: {
-        boxShadow:
-          '2px 3px 12px -2px rgba(0,0,0,.3), 1px 1px 4px rgba(0,0,0,.3), 1px 1px 2px rgba(0,0,0,.3)',
+        // boxShadow:
+        //   '2px 3px 12px -2px rgba(0,0,0,.3), 1px 1px 4px rgba(0,0,0,.3), 1px 1px 2px rgba(0,0,0,.3)',
       },
     },
     {
       isFilled: true,
       isDarkMode: false,
       css: {
-        boxShadow:
-          '2px 3px 12px -2px rgba(0,0,0,.2), 1px 1px 4px rgba(0,0,0,.16),  1px 1px 2px rgba(0,0,0,.16)',
+        // boxShadow:
+        //   '2px 3px 12px -2px rgba(0,0,0,.2), 1px 1px 4px rgba(0,0,0,.16),  1px 1px 2px rgba(0,0,0,.16)',
       },
     },
   ],

--- a/packages/tldraw/src/state/shapes/RectangleUtil/RectangleUtil.tsx
+++ b/packages/tldraw/src/state/shapes/RectangleUtil/RectangleUtil.tsx
@@ -84,8 +84,13 @@ export class RectangleUtil extends TDShapeUtil<T, E> {
             color={styles.stroke}
             offsetX={(labelPoint[0] - 0.5) * bounds.width}
             offsetY={(labelPoint[1] - 0.5) * bounds.height}
+            shape={shape}
           />
-          <SVGContainer id={shape.id + '_svg'} opacity={isGhost ? GHOSTED_OPACITY : 1}>
+          <SVGContainer
+            id={shape.id + '_svg'}
+            opacity={isGhost ? GHOSTED_OPACITY : 1}
+            shapeStyle={style}
+          >
             {isBinding && <BindingIndicator strokeWidth={styles.strokeWidth} size={size} />}
             <Component
               id={id}

--- a/packages/tldraw/src/state/shapes/TDShapeUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TDShapeUtil.tsx
@@ -186,6 +186,7 @@ export abstract class TDShapeUtil<T extends TDShape, E extends Element = any> ex
       const bounds = this.getBounds(shape)
       const labelElm = getTextSvgElement(s['label'], shape.style, bounds)
       labelElm.setAttribute('fill', getShapeStyle(shape.style, isDarkMode).stroke)
+      labelElm.setAttribute('data-color', shape.style.color)
       const font = getFontStyle(shape.style)
       const size = getTextLabelSize(s['label'], font)
       labelElm.setAttribute('transform-origin', 'top left')

--- a/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
@@ -179,6 +179,7 @@ export class TextUtil extends TDShapeUtil<T, E> {
                 color: styles.stroke,
                 textAlign: getTextAlign(style.textAlign),
               }}
+              data-color={shape.style.color}
             >
               {isBinding && (
                 <div
@@ -340,7 +341,8 @@ export class TextUtil extends TDShapeUtil<T, E> {
     const bounds = this.getBounds(shape)
     const style = getShapeStyle(shape.style, isDarkMode)
     const elm = getTextSvgElement(shape.text, shape.style, bounds)
-    elm.setAttribute('fill', style.stroke)
+    elm.setAttribute('data-fill', style.stroke)
+    elm.setAttribute('data-color', shape.style.color)
 
     return elm
   }

--- a/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
@@ -341,7 +341,6 @@ export class TextUtil extends TDShapeUtil<T, E> {
     const bounds = this.getBounds(shape)
     const style = getShapeStyle(shape.style, isDarkMode)
     const elm = getTextSvgElement(shape.text, shape.style, bounds)
-    elm.setAttribute('data-fill', style.stroke)
     elm.setAttribute('data-color', shape.style.color)
 
     return elm

--- a/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx
@@ -341,6 +341,7 @@ export class TextUtil extends TDShapeUtil<T, E> {
     const bounds = this.getBounds(shape)
     const style = getShapeStyle(shape.style, isDarkMode)
     const elm = getTextSvgElement(shape.text, shape.style, bounds)
+    elm.setAttribute('fill', style.stroke)
     elm.setAttribute('data-color', shape.style.color)
 
     return elm

--- a/packages/tldraw/src/state/shapes/TriangleUtil/TriangleUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TriangleUtil/TriangleUtil.tsx
@@ -94,8 +94,13 @@ export class TriangleUtil extends TDShapeUtil<T, E> {
             isEditing={isEditing}
             onChange={handleLabelChange}
             onBlur={onShapeBlur}
+            shape={shape}
           />
-          <SVGContainer id={shape.id + '_svg'} opacity={isGhost ? GHOSTED_OPACITY : 1}>
+          <SVGContainer
+            id={shape.id + '_svg'}
+            opacity={isGhost ? GHOSTED_OPACITY : 1}
+            shapeStyle={style}
+          >
             {isBinding && <TriangleBindingIndicator size={size} />}
             <Component
               id={id}

--- a/packages/tldraw/src/state/shapes/shared/TextLabel.tsx
+++ b/packages/tldraw/src/state/shapes/shared/TextLabel.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
 import { stopPropagation } from '~components/stopPropagation'
-import { GHOSTED_OPACITY,  LETTER_SPACING } from '~constants'
+import { GHOSTED_OPACITY, LETTER_SPACING } from '~constants'
 import { TLDR } from '~state/TLDR'
 import { styled } from '~styles'
 import { getTextLabelSize } from './getTextSize'
 import { TextAreaUtils } from './TextAreaUtils'
+import { TDShape } from '~types'
 
 export interface TextLabelProps {
   font: string
@@ -16,6 +17,7 @@ export interface TextLabelProps {
   offsetX?: number
   scale?: number
   isEditing?: boolean
+  shape?: TDShape
 }
 
 export const TextLabel = React.memo(function TextLabel({
@@ -28,6 +30,7 @@ export const TextLabel = React.memo(function TextLabel({
   isEditing = false,
   onBlur,
   onChange,
+  shape,
 }: TextLabelProps) {
   const rInput = React.useRef<HTMLTextAreaElement>(null)
   const rIsMounted = React.useRef(false)
@@ -139,6 +142,7 @@ export const TextLabel = React.memo(function TextLabel({
           font,
           color,
         }}
+        data-color={shape?.style.color}
       >
         {isEditing ? (
           <TextArea


### PR DESCRIPTION
This PR adds data attributes to shapes so we can target them with CSS. This will allow us to apply our own styling to Tldraw elements, without modifying too much of the underlying code.

This required changing a few key elements:
- `SVGContainer` is used for both drawing shapes in the editor, and generating SVGs. Adding style props to the `g` element inside it means they'll be available in both contexts.
- `TextUtil` is a special snowflake since Tldraw doesn't use SVGs for those in the editor. I updated the editor representation, and the generateSvg metho here.
- Same goes for `TextLabel` which is used for text inside the other shapes.
- The various shape utils, eg `RectangleUtil`, were updated to pass the added props to SVGContainer and TextLabel
- I also removed the drop shadow on images, which was kind of its own thing

Here's an example of CSS we can write now. I confirmed this works locally but commented it out.
```
[data-color=violet] {
  color: green !important;
}

[data-color=violet] [stroke] {
  stroke: green !important;
}

[data-color=violet] [fill] {
  fill: green !important;
}
```
