### PR TITLE
Fix text labels in SVGs

### DIFF
--- a/packages/tldraw/package.json
+++ b/packages/tldraw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tldraw/tldraw",
-  "version": "1.24.7",
+  "version": "1.24.8",
   "description": "A tiny little drawing app (editor)",
   "author": "@steveruizok",
   "repository": {

--- a/packages/tldraw/src/state/shapes/TriangleUtil/TriangleUtil.tsx
+++ b/packages/tldraw/src/state/shapes/TriangleUtil/TriangleUtil.tsx
@@ -255,7 +255,7 @@ export class TriangleUtil extends TDShapeUtil<T, E> {
         s.label!,
         fontSize,
         fontFamily,
-        AlignStyle.Start,
+        AlignStyle.Middle,
         size[0],
         false
       )

--- a/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
+++ b/packages/tldraw/src/state/shapes/shared/getTextSvgElement.ts
@@ -108,7 +108,7 @@ function breakText(opts: {
   // Split the text into words
   const words = opts.text
     .split(wordSeparator)
-    .flatMap((word) => word.replace('\n', ' \n'))
+    .flatMap((word) => word.replaceAll('\n', ' \n'))
     .join(' ')
     .split(' ')
 


### PR DESCRIPTION
- Fix triangle labels aligning left instead of center
- Fix linebreaks after the first not working in SVGs
- Bump version